### PR TITLE
Extended functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# twitter data
+data/

--- a/README.md
+++ b/README.md
@@ -19,27 +19,38 @@ Usage:
 ```bash
 # Get an archive from https://twitter.com/settings/download_your_data
 # Unzip a Twitter archive so the assets/ folder is in the same directory as main.py
+git clone https://github.com/ianklatzco/twitter-to-bsky.git
+cd twitter-to-bsky
+# Create virtual environment for python
+python3 -m venv ./venv
+# Install requirements
+./venv/bin/pip install -r Requirements.txt
+# Copy your twitter archive to ./data/
+cp -r _pathToArchive_/data ./
+# Use a space in front of the PASSWORD export to prevent it from going to your bash history
 export BSKY_USERNAME="yourname.bsky.social"
-export PASSWORD="yourpassword"
-pip install atprototools==0.0.6
-python main.py
+ export PASSWORD="yourpassword"
+./venv/bin/python3 main.py
 ```
 
 ### Known problems
 
-Bluesky's UI currently renders timestamps based on the indexedAt field (i.e., when the skoot was skooted) rather than the createdAt field (when the skoot CLAIMS it was skooted).
+Bluesky's UI currently renders timestamps based on the indexedAt field (i.e., when the bloot was blooted) rather than the createdAt field (when the bloot CLAIMS it was blooted).
 
 The code here currently tries to post skoots with the old timestamps, but the Bluesky UI will not render them so. It used to, and then Paul probably patched the bug ^^
 
 Does not preserve replies, so your threads will be decomposed into de-contextualized individual posts.
 
-Does not convert links in the text of tweets.
+~~Does not convert links in the text of tweets.~~ Now converts links, including those to your own tweets!
+
+Supports blooting only a single image tweet (multiple image tweets will be skipped) _(From @webash: the export I was testing with only had single image tweets))_
 
 ### Thanks to
 
 - Boris Mann
 - Shinya Kato
 - [Heartade](https://github.com/Heartade)
+- [WebAsh](https://github.com/WebAsh)
 
 ### See also
 

--- a/Requirements.txt
+++ b/Requirements.txt
@@ -1,0 +1,1 @@
+atprototools==0.0.17


### PR DESCRIPTION
Thank you so much for writing this initial script! I've added a few upgrades and thought I'd contribute them back.

- Rewrites `t.co` links to their external equivalent (text only)
- Rewrites `t.co` links to your own tweets as text-based retweets
- Rewrites `t.co` links to other account tweets to `x.com` links
- Tweets with one image will upload the image along with the tweet
- More status printing so you can see what happened
- Upgraded to `atprototools==0.0.17` and added a `Requirements.txt`
- Changed terminology from skoot to bloot to match the library
- Made the `wipe_profile()` function more generic so anyone could use it to clear down their profile before they import tweets