### PR TITLE
Force opens file as utf8 per #16 and #19

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ USERNAME = os.environ.get("BSKY_USERNAME")
 PASSWORD = os.environ.get("PASSWORD")
 
 
-f = open(TWEETS_JS_PATH)
+f = open(TWEETS_JS_PATH, encoding="utf8")
 c = f.read().replace("window.YTD.tweets.part0 = ", "")
 tweets = json.loads(c)
 


### PR DESCRIPTION
Ensures file is opened at `utf8` encoding for best compatibility with non-English characters.

This resolves #16 and #19 